### PR TITLE
Remove .env from git repo

### DIFF
--- a/api/.env
+++ b/api/.env
@@ -1,1 +1,0 @@
-MONGO_URL = mongodb+srv://mongomike770:63987calibration99033@cluster0.2orzcxu.mongodb.net/spiral-mountain?retryWrites=true&w=majority


### PR DESCRIPTION
Access to MongoDB server compromised, password present in .env file pushed to repo. Removed .env with git rm --cached. Updated password.