### PR TITLE
Reverted to original proxy method

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -37,9 +37,5 @@
       "last 1 safari version"
     ]
   },
-  "proxy": {
-    "/api/": {
-        "target": "http://localhost:5000"
-    }
-}
+  "proxy": "http://localhost:5000/api/"
 }

--- a/client/src/pages/home/Home.jsx
+++ b/client/src/pages/home/Home.jsx
@@ -2,6 +2,7 @@ import "./home.css"
 import Posts from '../../components/posts/Posts';
 import { useEffect, useState } from "react";
 import axios from "axios";
+// import setupProxy from "../../setupProxy";
 
 // axios.defaults.baseURL = "http://localhost5000/api/"
 
@@ -11,7 +12,7 @@ export default function Home() {
     useEffect(() => {
         const fetchPosts = async () => {
             const res = await axios.get("/posts");
-            setPosts(res.data)
+            console.log(res)
         };
         fetchPosts();
     },[]);


### PR DESCRIPTION
After a week of troubleshooting, returned to original method (package.json simple proxy request), tested it a few times (npm start client then api then refresh worked, npm start api then client worked). Incrimental updates from here out to avoid problems.