### PR TITLE
Axios Get Error Solution

### DIFF
--- a/client/src/components/postPage/PostPage.jsx
+++ b/client/src/components/postPage/PostPage.jsx
@@ -7,11 +7,11 @@ export default function PostPage() {
     const location = useLocation();
     const path = location.pathname.split("/")[2];
     const [post, setPost] = useState({});
-
+    
     
     useEffect(() => {
         const getPost = async () =>  {
-            const res = await axios.get("/post/" + path);
+            const res = await axios.get("/posts/" + path);
             console.log(res);
             setPost(res.data);
         };


### PR DESCRIPTION
Axios get request was being directed at the wrong location, "/post/", where correct location was "/posts/". One letter can make all the difference!

Each page link on homepage now leads to its own fullscreen page, populated by data from that specific post.