### PR TITLE
Schema and post identifier update

### DIFF
--- a/api/models/Post.js
+++ b/api/models/Post.js
@@ -19,6 +19,11 @@ const PostSchema = new mongoose.Schema(
         type:String,
         required:true,
     },
+    usernameId:{
+        type:String,
+        required:true,
+        immutable: true, //this value will never change
+    }, //NEW^
     categories:{
         type:Array,
         required:false

--- a/api/models/User.js
+++ b/api/models/User.js
@@ -9,7 +9,8 @@ const UserSchema = new mongoose.Schema({
     email:{
         type:String,
         required:true,
-        unique:true
+        unique:true,
+        lowercase:true,
     },
     password:{
         type:String,

--- a/api/routes/posts.js
+++ b/api/routes/posts.js
@@ -17,21 +17,23 @@ router.post("/", async (req, res)=>{
 router.put("/:id", async (req, res)=>{
     try{
         const post = await Post.findById(req.params.id);
-        if(post.username === req.body.username){
-        
-        try{
-            const updatedPost = await Post.findByIdAndUpdate(req.params.id, {
-                $set:req.body,
-            },
-            { new: true }
-            );
-            res.status(200).json(updatedPost);
-        } catch(err){
-            res.status(500).json(err);
+        if(post.usernameId === req.body.usernameId){
+            //NEW above previously had usernameId as username...
+            //GOAL: usernameId linked to post === current user id#. 
+            try{
+                const updatedPost = await Post.findByIdAndUpdate(req.params.id, {
+                    $set:req.body,
+                },
+                { new: true }
+                );
+                res.status(200).json(updatedPost);
+            } catch(err){
+                res.status(500).json(err);
+                console.log("backend error checks");
+            }
+        } else{
+            res.status(401).json("You can only update your own posts");
         }
-    } else{
-        res.status(401).json("You can only update your own posts");
-    }
     } catch(err){
         res.status(500).json(err);
     }
@@ -41,16 +43,18 @@ router.put("/:id", async (req, res)=>{
 router.delete("/:id", async (req, res)=>{
     try{
         const post = await Post.findById(req.params.id);
-        if(post.username === req.body.username){
-        try{
-            await post.delete()
-            res.status(200).json("Post successfully deleted");
-        } catch(err){
-            res.status(500).json(err);
+        if(post.usernameId === req.body._id){
+            //NEW^ username switched to usernameId, since ID# cannot be updated (only screen name)
+            //may need to change req.body.usernameId to req.body._id
+            try{
+                await post.delete()
+                res.status(200).json("Post successfully deleted");
+            } catch(err){
+                res.status(500).json(err);
+            }
+        } else{
+            res.status(401).json("You can only delete your own posts");
         }
-    } else{
-        res.status(401).json("You can only delete your own posts");
-    }
     } catch(err){
         res.status(500).json(err);
     }
@@ -79,13 +83,13 @@ router.get("/", async (req,res)=>{
                 $in:[catName],
             },
         });
-        } else{
-            posts = await Post.find();
-        }
-        res.status(200).json(posts);
-    } catch (err) {
-        res.status(500).json(err);
+    } else{
+        posts = await Post.find();
     }
+    res.status(200).json(posts);
+} catch (err) {
+    res.status(500).json(err);
+}
 });
 
 module.exports = router

--- a/api/routes/users.js
+++ b/api/routes/users.js
@@ -34,10 +34,13 @@ router.delete("/:id", async (req, res)=>{
        try{
             const user = await User.findById(req.params.id);
            try{
-                await Post.deleteMany({username:user.username});
+                await Post.deleteMany({usernameId:user.id});
                 //^set to delete all posts associated with user
-               await User.findByIdAndDelete(req.params.id);
-               res.status(200).json("User successfully deleted");
+                //^^may need to be updated with new usernameId data added to each post as main identifier
+                //^^^updated from {username:user.username} to usernameId:user._id
+                //^^^^This seems to be the current major problem child
+                await User.findByIdAndDelete(req.params.id);
+                res.status(200).json("User successfully deleted");
             } catch(err){
                 res.status(500).json(err);
             }

--- a/client/src/components/postPage/PostPage.jsx
+++ b/client/src/components/postPage/PostPage.jsx
@@ -12,6 +12,8 @@ export default function PostPage() {
 	const { user } = useContext(Context);
 	const [title, setTitle] = useState('');
 	const [desc, setDesc] = useState('');
+	const [author, setAuthor] = useState('');
+	const [usernameId, setUsernameId] = useState('');
 	const [updateMode, setUpdateMode] = useState(false);
     
     
@@ -22,14 +24,29 @@ export default function PostPage() {
 			setPost(res.data);
 			setTitle(res.data.title);
 			setDesc(res.data.desc);
+			setAuthor(res.data.username);
+			setUsernameId(res.data.usernameId);
+			// if(user._id === res._id){
+			// 	setAuthor(user.username);
+			// }
 		};
 		getPost();
 	}, [path]);
 
+	// const updateAuthor = () => {
+	// 	if(user._id ===  post.usernameId){
+	// 		setAuthor(user.username);
+	// 	}
+	// };
+	// updateAuthor();
+	//^^ attempting to ensure that posts stay updated with updated 
+	// usernames. may be something that needs to be handled in settings
+	//page since that's where name update occurs?
+
 	const handleDelete = async () => {
 		try{
 			await axios.delete(`/posts/${post._id}`, {
-				data:{username:user.username},
+				data:{usernameId:user._id},
 			});
 			console.log('Post successfully deleted');
 			window.location.replace('/');
@@ -44,16 +61,23 @@ export default function PostPage() {
 				username:user.username, 
 				title, 
 				desc,
+				usernameId,
 			});
+			if (usernameId === user._id) {
+				setAuthor(user.username);// New attempt to create post/username parity
+			}
 			console.log('Post successfully updated');
 			setUpdateMode(false);
 		}catch (err) {
 			console.log('Error updating post');
+			console.log(post.usernameId);
+			console.log(user._id);
+			console.log(post.usernameId === user._id);
 		}
 	};
-
+	console.log(user._id);
 	return (
-		<div className="postPage">
+		<div className="postPage" >
 			<div className='singlePostWrapper'>
 				<img 
 					src={PUBLICFOLDER + post.photo} 
@@ -70,7 +94,7 @@ export default function PostPage() {
 					/>) : (
 					<h1 className='singlePostTitle'>
 						{title}
-						{post.username === user?.username && (
+						{post.usernameId === user._id && (
 							<div className='editSinglePost'>
 								<i className="singlePostIcon fa-regular fa-pen-to-square" onClick={()=>setUpdateMode(true)}></i>
 								<i className="singlePostIcon fa-regular fa-trash-can" onClick={handleDelete}></i>
@@ -79,7 +103,7 @@ export default function PostPage() {
 					</h1>
 				)}
 				<div className='singlePostInfo'>
-					<span className='singlePostAuthor'>Author: <b>{post.username}</b></span>
+					<span className='singlePostAuthor'>Author: <b>{author}</b></span>
 					<span className='singlePostDate'>{new Date(post.createdAt).toDateString()}</span>
 				</div>
 				{updateMode ? (

--- a/client/src/pages/settings/Settings.jsx
+++ b/client/src/pages/settings/Settings.jsx
@@ -36,6 +36,12 @@ export default function Settings() {
 		}
 		try{
 			const res = await axios.put('/users/' + user._id, updatedUser );
+			await axios.put(`/posts/${user._id}`, {
+				username: updatedUser.username
+			});
+			// add line that adds await axios.put ('/posts/'), updates posts tied to user
+			//with updated username?
+			//above should retroactively update usernames of previous posts
 			dispatch({type:'update_success', payload: res.data});
 			setSuccess(true);
 		} catch (err){
@@ -63,7 +69,7 @@ export default function Settings() {
 		}
 	};
 
-	console.log('http://localhost:3000/users/' + `${user._id}`);
+	// console.log('http://localhost:3000/users/' + `${user._id}`);
 	return (
 		<div className='Settings'>
 			<div className='settingsWrapper'>

--- a/client/src/pages/write/Write.jsx
+++ b/client/src/pages/write/Write.jsx
@@ -15,6 +15,8 @@ export default function Write() {
 			username: user.username,
 			title,
 			desc,
+			usernameId: user._id, //NEWLY ADDED: should add the unique user id # to each post 
+			//(also udpated the post model schema to include usernameId)
 		};
 		if (file) {
 			const data = new FormData();


### PR DESCRIPTION
API updated so that posts are now created with the posting user's unique ID# as the core identifier, rather than the user's username. Since username's could be easily changed, this proved to be a problem, removing users' ability to update and delete their own older posts under a former username. Also, upon post update, the author's username is also automatically updated. Future update will make this automatic upon user update in Settings.jsx.