### PR TITLE
Style update: photos, linebreaks, centering

### DIFF
--- a/client/src/components/postPage/PostPage.jsx
+++ b/client/src/components/postPage/PostPage.jsx
@@ -26,22 +26,9 @@ export default function PostPage() {
 			setDesc(res.data.desc);
 			setAuthor(res.data.username);
 			setUsernameId(res.data.usernameId);
-			// if(user._id === res._id){
-			// 	setAuthor(user.username);
-			// }
 		};
 		getPost();
 	}, [path]);
-
-	// const updateAuthor = () => {
-	// 	if(user._id ===  post.usernameId){
-	// 		setAuthor(user.username);
-	// 	}
-	// };
-	// updateAuthor();
-	//^^ attempting to ensure that posts stay updated with updated 
-	// usernames. may be something that needs to be handled in settings
-	//page since that's where name update occurs?
 
 	const handleDelete = async () => {
 		try{
@@ -79,11 +66,19 @@ export default function PostPage() {
 	return (
 		<div className="postPage" >
 			<div className='singlePostWrapper'>
-				<img 
-					src={PUBLICFOLDER + post.photo} 
-					alt='' 
-					className='singlePostImg'
-				/>
+				{ post.photo && (
+					<img 
+						src={PUBLICFOLDER + post.photo} 
+						alt='' 
+						className='singlePostImg'
+					/>
+				) || (
+					<img 
+						src='https://images.unsplash.com/photo-1580912458702-6fa698fc553e?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1470&q=80'
+						alt='Default post image' 
+						className='singlePostImg'
+					/>
+				)}
 				{updateMode ? (
 					<input
 						type='text' 
@@ -110,10 +105,11 @@ export default function PostPage() {
 					<textarea 
 						className='singlePostDescInput' 
 						value={desc}
-						onChange={(e)=>setDesc(e.target.value)}	
+						onChange={(e)=>setDesc(e.target.value)}
+						style={{ whiteSpace: 'pre-wrap' }}	
 					/>
 				) : (
-					<p className='singlePostDesc'>
+					<p className='singlePostDesc' style={{ whiteSpace: 'pre-wrap' }}>
 						{desc}
 					</p>
 				)}

--- a/client/src/components/posts/posts.css
+++ b/client/src/components/posts/posts.css
@@ -1,6 +1,7 @@
 .posts {
     display: flex;
     flex-wrap: wrap;
+    justify-content: center;
     margin: 30px;
     font-family: CCComicrazy, Arial, Helvetica, sans-serif;
     color: white;

--- a/client/src/components/singlepost/SinglePost.jsx
+++ b/client/src/components/singlepost/SinglePost.jsx
@@ -17,8 +17,7 @@ export default function SinglePost({post}) {
 			) || (
 				<img 
 					className="postImg"
-					src="https://images.unsplash.com/photo-1606144042614-b2417e99c4e3?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1170&q=80"
-					// above source should be a good backup image
+					src='https://images.unsplash.com/photo-1580912458702-6fa698fc553e?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1470&q=80'
 					alt="Placeholder post image: the Playstation 5 home console on a white background"
 				/>
 			)}

--- a/client/src/components/singlepost/singlepost.css
+++ b/client/src/components/singlepost/singlepost.css
@@ -5,7 +5,7 @@
 
 .postImg {
     width: 100%;
-    height: 280px;
+    height: 180px;
     object-fit: cover;
     border-radius: 5px;
 }

--- a/client/src/pages/write/Write.jsx
+++ b/client/src/pages/write/Write.jsx
@@ -43,7 +43,6 @@ export default function Write() {
 			{file && 
 			<img 
 				className="writeImg"
-				// src="https://images.unsplash.com/photo-1606144042614-b2417e99c4e3?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1170&q=80"
 				src={URL.createObjectURL(file)}
 				alt=""
 			/>
@@ -72,6 +71,7 @@ export default function Write() {
 						type="text"
 						className='writeInput writeText'
 						onChange={(e)=>setDesc(e.target.value)}
+						style={{ whiteSpace: 'pre-wrap' }}
 					></textarea>
 				</div>
 				<button className='writeSubmit' type='submit'>Publish</button>


### PR DESCRIPTION
Hompage posts.css updated with justify-content: center to center the page content.

New code provides default image to posts without a user-added post image. Post image defaults on hompage and post page udpated to honeycomb: more neutral than the PS5, and goes well with theme.

Whitespace:pre-wrap styling adds recognition of user inputted spacing, so post indents and line breaks can be used to make for a more enjoyable and organized reading experience.