### PR TITLE
Linebreak-style issue

### DIFF
--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -21,10 +21,7 @@ module.exports = { /*global module */
 			'error',
 			'tab'
 		],
-		'linebreak-style': [
-			'error',
-			'windows'
-		],
+		'linebreak-style':0,
 		'quotes': [
 			'error',
 			'single'

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -17,7 +17,7 @@ import { Context } from './context/Context';
 
 function App() {
 	const { user } = useContext(Context);
-	// guest account will render user true
+
 	return (
 		<Router>
 			<TopBar />


### PR DESCRIPTION
Netlify npm run build command fails likely because of massive influx of eslint errors related to linebreak-style throughout the frontend-- specifically that CRLF is expected, but style is in LF. Unknown why these errors are appearing; after checking each individual file under client directory, every single one is set to CRLF. Linebreak-style removed from eslintrc.js in attempt to remedy issue and deploy.