### PR TITLE
Update API port

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -67,7 +67,10 @@ mongoose.connection.once('open', () => {
     app.use("/api/posts", postRoute);
     app.use("/api/categories", categoryRoute);
 
-    app.listen("5000", () => {
+
+    const port = "443";
+
+    app.listen(port, () => {
         console.log("Backend is running.")
     });
 });


### PR DESCRIPTION
Render.com backend deployment continues to fail, without giving a clear error response. Current hunch is that it's due to the fact that the backend was listening for port 5000, when the HTTPS is located at port 443.