### PR TITLE
Update index.js

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -71,7 +71,7 @@ app.get('/users/new', (req, res) => {
     console.log('User New Form')
 });
 
-mongoose.connection.once('open', () => {
+mongoose.connection.on('open', () => {
     console.log('Connected to MongoDB');
 
     app.use("/api/auth", authRoute);


### PR DESCRIPTION
Transfer start event during api call is taking a long time.. anywhere from 20 seconds to a staggering 1 minute 14 seconds. All other processes are under a second. Attempting to reduce delays in server requests by changing mongoose.connection.once to mongoose.connection.on.