### PR TITLE
Revert "Add backend URL to ACAO"

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -19,7 +19,7 @@ dotenv.config();
 app.use(express.json());
 
 app.use((req, res, next) => {
-  res.setHeader("Access-Control-Allow-Origin", "https://www.spiral-mountain.com, https://spiral-mountain-api.onrender.com/");
+  res.setHeader("Access-Control-Allow-Origin", "https://www.spiral-mountain.com");
   res.setHeader(
     "Access-Control-Allow-Headers",
     "Origin, X-Requested-With, Content-Type, Accept, Authorization"


### PR DESCRIPTION
Reverts Gitmsl/spiral-mountain#84

Resulted in error: Access to XMLHttpRequest at 'https://spiral-mountain-api.onrender.com/api/posts' from origin 'https://www.spiral-mountain.com' has been blocked by CORS policy: The 'Access-Control-Allow-Origin' header contains multiple values 'https://www.spiral-mountain.com, https://spiral-mountain-api.onrender.com/', but only one is allowed.